### PR TITLE
Add support for environment variables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Add `ByName.Name()` method, which returns the dependency name as a string
 - Add `FromGroup.Group()` method, which returns the group name as a string
+- Add support for depending on environment variables
 
 ### Changed
 

--- a/declaration.go
+++ b/declaration.go
@@ -48,6 +48,12 @@ type decoratorEntry[T any] struct {
 	Decorator decorator[T]
 }
 
+// selfConstructor is an interface for types that construct themselves without a
+// user-defined constructor function.
+type selfConstructor interface {
+	constructSelf(*Context) error
+}
+
 // declarationOf describes how to build values of type T.
 type declarationOf[T any] struct {
 	m sync.Mutex
@@ -219,6 +225,10 @@ func (d *declarationOf[T]) construct(ctx *Context) error {
 		}
 
 		return nil
+	}
+
+	if sc, ok := any(&d.value).(selfConstructor); ok {
+		return sc.constructSelf(ctx)
 	}
 
 	panic(fmt.Sprintf(

--- a/environment.go
+++ b/environment.go
@@ -29,7 +29,8 @@ type EnvironmentVariable[T Parseable] interface {
 type Parseable interface {
 	string |
 		int | int16 | int32 | int64 |
-		uint | uint16 | uint32 | uint64
+		uint | uint16 | uint32 | uint64 |
+		float32 | float64
 }
 
 // FromEnvironment requests a dependency from the environment.
@@ -109,6 +110,11 @@ func parseInto(value string, out any) error {
 	case *uint64:
 		return parseUint(value, 64, out)
 
+	case *float32:
+		return parseFloat(value, 32, out)
+	case *float64:
+		return parseFloat(value, 64, out)
+
 	default:
 		panic(fmt.Sprintf(
 			"%s implements the Parseable constraint, but is not handled by the parser",
@@ -137,6 +143,21 @@ func parseInt[T constraints.Signed](value string, size int, out *T) error {
 // parseUint parses an unsigned integer and assigns it to *out.
 func parseUint[T constraints.Unsigned](value string, size int, out *T) error {
 	n, err := strconv.ParseUint(value, 10, size)
+	if err != nil {
+		return fmt.Errorf(
+			"%#v is not a valid %s",
+			value,
+			typeOf[T](),
+		)
+	}
+
+	*out = T(n)
+	return nil
+}
+
+// parseFloat parses a float and assigns it to *out.
+func parseFloat[T constraints.Float](value string, size int, out *T) error {
+	n, err := strconv.ParseFloat(value, size)
 	if err != nil {
 		return fmt.Errorf(
 			"%#v is not a valid %s",

--- a/environment.go
+++ b/environment.go
@@ -1,0 +1,138 @@
+package imbue
+
+import (
+	"fmt"
+	"math/bits"
+	"os"
+	"reflect"
+	"strconv"
+
+	"golang.org/x/exp/constraints"
+)
+
+// EnvironmentVariable is a constraint for a type that identifies an environment
+// variable.
+//
+// Environment variables are declared by declaring a type that uses
+// imbue.Name[T] as its underlying type, where T is the type of the dependency
+// being named.
+type EnvironmentVariable[T Parseable] interface {
+	variableOfType(T)
+}
+
+// Parseable is a constraint that identifies the set of types that can be parsed
+// from their string representation, such as in an environment variable.
+type Parseable interface {
+	string |
+		int | int16 |
+		uint | uint16 // TODO: add other built-in types
+}
+
+// FromEnvironment requests a dependency from the environment.
+//
+// It is used as a parameter type within user-defined functions passed to
+// WithX(), DecorateX(), and InvokeX() to request a dependency of type T that is
+// named N.
+type FromEnvironment[N EnvironmentVariable[T], T Parseable] struct {
+	value T
+}
+
+// Name returns the name of the environment variable.
+func (v FromEnvironment[N, T]) Name() string {
+	return typeOf[N]().Name()
+}
+
+// Value returns the parsed value of the environment variable.
+func (v FromEnvironment[N, T]) Value() T {
+	return v.value
+}
+
+// String returns the original string value of the environment variable.
+func (v FromEnvironment[N, T]) String() string {
+	return os.Getenv(v.Name())
+}
+
+// constructSelf constructs the environment variable in-place.
+func (v *FromEnvironment[N, T]) constructSelf(ctx *Context) error {
+	name := v.Name()
+	value, ok := os.LookupEnv(name)
+	if !ok {
+		return fmt.Errorf(
+			"the %s environment variable is not defined",
+			name,
+		)
+	}
+
+	if value == "" {
+		return fmt.Errorf(
+			"the %s environment variable is defined, but it is empty",
+			name,
+		)
+	}
+
+	if err := parseInto(value, &v.value); err != nil {
+		return fmt.Errorf(
+			"the %s environment variable cannot be parsed: %w",
+			name,
+			err,
+		)
+	}
+
+	return nil
+}
+
+// parseInto parses value into *out.
+func parseInto(value string, out any) error {
+	switch out := out.(type) {
+	case *string:
+		*out = value
+
+	case *int:
+		return parseInt(value, bits.UintSize, out)
+	case *int16:
+		return parseInt(value, 16, out)
+
+	case *uint:
+		return parseUint(value, bits.UintSize, out)
+	case *uint16:
+		return parseUint(value, 16, out)
+
+	default:
+		panic(fmt.Sprintf(
+			"%s implements the Parseable constraint, but is not handled by the parser",
+			reflect.TypeOf(out).Elem(),
+		))
+	}
+
+	return nil
+}
+
+// parseInt parses a signed integer and assigns it to *out.
+func parseInt[T constraints.Signed](value string, size int, out *T) error {
+	n, err := strconv.ParseInt(value, 10, size)
+	if err != nil {
+		return fmt.Errorf(
+			"%#v is not a valid %s",
+			value,
+			typeOf[T](),
+		)
+	}
+
+	*out = T(n)
+	return nil
+}
+
+// parseUint parses an unsigned integer and assigns it to *out.
+func parseUint[T constraints.Unsigned](value string, size int, out *T) error {
+	n, err := strconv.ParseUint(value, 10, size)
+	if err != nil {
+		return fmt.Errorf(
+			"%#v is not a valid %s",
+			value,
+			typeOf[T](),
+		)
+	}
+
+	*out = T(n)
+	return nil
+}

--- a/environment.go
+++ b/environment.go
@@ -33,7 +33,8 @@ type EnvironmentVariable[T Parseable] interface {
 // Parseable is a constraint that identifies the set of types that can be parsed
 // from their string representation, such as in an environment variable.
 type Parseable interface {
-	string |
+	// Strings and byte-slices are direct representations of the parsed value.
+	string | []byte |
 
 		// Booleans are required to be explicitly set to one of "true", "false",
 		// "yes", "no", "on" or "off". The value is case-insensitive.
@@ -119,7 +120,8 @@ func parseInto(value string, out any) error {
 	switch out := out.(type) {
 	case *string:
 		*out = value
-
+	case *[]byte:
+		*out = []byte(value)
 	case *bool:
 		return parseBool(value, out)
 

--- a/environment.go
+++ b/environment.go
@@ -36,28 +36,28 @@ type Parseable interface {
 //
 // It is used as a parameter type within user-defined functions passed to
 // WithX(), DecorateX(), and InvokeX() to request a dependency of type T that is
-// named N.
-type FromEnvironment[N EnvironmentVariable[T], T Parseable] struct {
+// parsed from the environment variable V.
+type FromEnvironment[V EnvironmentVariable[T], T Parseable] struct {
 	value T
 }
 
 // Name returns the name of the environment variable.
-func (v FromEnvironment[N, T]) Name() string {
-	return typeOf[N]().Name()
+func (v FromEnvironment[V, T]) Name() string {
+	return typeOf[V]().Name()
 }
 
 // Value returns the parsed value of the environment variable.
-func (v FromEnvironment[N, T]) Value() T {
+func (v FromEnvironment[V, T]) Value() T {
 	return v.value
 }
 
 // String returns the original string value of the environment variable.
-func (v FromEnvironment[N, T]) String() string {
+func (v FromEnvironment[V, T]) String() string {
 	return os.Getenv(v.Name())
 }
 
 // constructSelf constructs the environment variable in-place.
-func (v *FromEnvironment[N, T]) constructSelf(ctx *Context) error {
+func (v *FromEnvironment[V, T]) constructSelf(ctx *Context) error {
 	name := v.Name()
 	value, ok := os.LookupEnv(name)
 	if !ok {

--- a/environment.go
+++ b/environment.go
@@ -28,8 +28,8 @@ type EnvironmentVariable[T Parseable] interface {
 // from their string representation, such as in an environment variable.
 type Parseable interface {
 	string |
-		int | int16 |
-		uint | uint16 // TODO: add other built-in types
+		int | int16 | int32 | int64 |
+		uint | uint16 | uint32 | uint64
 }
 
 // FromEnvironment requests a dependency from the environment.
@@ -95,11 +95,19 @@ func parseInto(value string, out any) error {
 		return parseInt(value, bits.UintSize, out)
 	case *int16:
 		return parseInt(value, 16, out)
+	case *int32:
+		return parseInt(value, 32, out)
+	case *int64:
+		return parseInt(value, 64, out)
 
 	case *uint:
 		return parseUint(value, bits.UintSize, out)
 	case *uint16:
 		return parseUint(value, 16, out)
+	case *uint32:
+		return parseUint(value, 32, out)
+	case *uint64:
+		return parseUint(value, 64, out)
 
 	default:
 		panic(fmt.Sprintf(

--- a/environment.go
+++ b/environment.go
@@ -14,8 +14,12 @@ import (
 // variable.
 //
 // Environment variables are declared by declaring a type that uses
-// imbue.Name[T] as its underlying type, where T is the type of the dependency
-// being named.
+// imbue.EnvironmentVariable[T] as its underlying type.
+//
+// The name of the declared type is used as the name of the environment
+// variable.
+//
+// T is the type that is produced by parsing the environment variable's value.
 type EnvironmentVariable[T Parseable] interface {
 	variableOfType(T)
 }

--- a/environment_test.go
+++ b/environment_test.go
@@ -2,6 +2,8 @@ package imbue_test
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"os"
 
 	"github.com/dogmatiq/imbue"
@@ -10,171 +12,161 @@ import (
 )
 
 type (
-	IMBUE_STRING imbue.EnvironmentVariable[string]
+	envTestString imbue.EnvironmentVariable[string]
 
-	IMBUE_INT   imbue.EnvironmentVariable[int]
-	IMBUE_INT16 imbue.EnvironmentVariable[int16]
-	IMBUE_INT32 imbue.EnvironmentVariable[int32]
-	IMBUE_INT64 imbue.EnvironmentVariable[int64]
+	envTestInt   imbue.EnvironmentVariable[int]
+	envTestInt16 imbue.EnvironmentVariable[int16]
+	envTestInt32 imbue.EnvironmentVariable[int32]
+	envTestInt64 imbue.EnvironmentVariable[int64]
 
-	IMBUE_UINT   imbue.EnvironmentVariable[uint]
-	IMBUE_UINT16 imbue.EnvironmentVariable[uint16]
-	IMBUE_UINT32 imbue.EnvironmentVariable[uint32]
-	IMBUE_UINT64 imbue.EnvironmentVariable[uint64]
+	envTestUint   imbue.EnvironmentVariable[uint]
+	envTestUint16 imbue.EnvironmentVariable[uint16]
+	envTestUint32 imbue.EnvironmentVariable[uint32]
+	envTestUint64 imbue.EnvironmentVariable[uint64]
 
-	IMBUE_FLOAT32 imbue.EnvironmentVariable[float32]
-	IMBUE_FLOAT64 imbue.EnvironmentVariable[float64]
+	envTestFloat32 imbue.EnvironmentVariable[float32]
+	envTestFloat64 imbue.EnvironmentVariable[float64]
 )
 
 var _ = Describe("func FromEnvironment()", func() {
-	var container *imbue.Container
-
-	BeforeEach(func() {
-		container = imbue.New()
-	})
-
-	AfterEach(func() {
-		container.Close()
-	})
-
 	It("can parse environment variables", func() {
-		expectEnv[IMBUE_STRING](container, "IMBUE_STRING", "<value>", "<value>")
+		expectEnv[envTestString]("ENV_TEST_STRING", "<value>", "<value>")
 
-		expectEnv[IMBUE_INT](container, "IMBUE_INT", "-123", int(-123))
-		expectEnv[IMBUE_INT16](container, "IMBUE_INT16", "-123", int16(-123))
-		expectEnv[IMBUE_INT32](container, "IMBUE_INT32", "-123", int32(-123))
-		expectEnv[IMBUE_INT64](container, "IMBUE_INT64", "-123", int64(-123))
+		expectEnv[envTestInt]("ENV_TEST_INT", "-123", int(-123))
+		expectEnv[envTestInt16]("ENV_TEST_INT16", "-123", int16(-123))
+		expectEnv[envTestInt32]("ENV_TEST_INT32", "-123", int32(-123))
+		expectEnv[envTestInt64]("ENV_TEST_INT64", "-123", int64(-123))
 
-		expectEnv[IMBUE_UINT](container, "IMBUE_UINT", "123", uint(123))
-		expectEnv[IMBUE_UINT16](container, "IMBUE_UINT16", "123", uint16(123))
-		expectEnv[IMBUE_UINT32](container, "IMBUE_UINT32", "123", uint32(123))
-		expectEnv[IMBUE_UINT64](container, "IMBUE_UINT64", "123", uint64(123))
+		expectEnv[envTestUint]("ENV_TEST_UINT", "123", uint(123))
+		expectEnv[envTestUint16]("ENV_TEST_UINT16", "123", uint16(123))
+		expectEnv[envTestUint32]("ENV_TEST_UINT32", "123", uint32(123))
+		expectEnv[envTestUint64]("ENV_TEST_UINT64", "123", uint64(123))
 
-		expectEnv[IMBUE_FLOAT32](container, "IMBUE_FLOAT32", "-123.45", float32(-123.45))
-		expectEnv[IMBUE_FLOAT64](container, "IMBUE_FLOAT64", "-123.45", float64(-123.45))
+		expectEnv[envTestFloat32]("ENV_TEST_FLOAT32", "-123.45", float32(-123.45))
+		expectEnv[envTestFloat64]("ENV_TEST_FLOAT64", "-123.45", float64(-123.45))
 	})
 
 	It("returns an error when an int cannot be parsed", func() {
-		expectEnvError[IMBUE_INT, int](
-			container,
-			"IMBUE_INT",
+		expectEnvError[envTestInt, int](
+			"ENV_TEST_INT",
 			"<not-numeric>",
-			`the IMBUE_INT environment variable cannot be parsed: "<not-numeric>" is not a valid int`,
+			fmt.Sprintf(
+				`the ENV_TEST_INT environment variable ("<not-numeric>") is invalid: expected integer between %d and %d`,
+				math.MinInt,
+				math.MaxInt,
+			),
 		)
 	})
 
 	It("returns an error when an int16 cannot be parsed", func() {
-		expectEnvError[IMBUE_INT16, int16](
-			container,
-			"IMBUE_INT16",
+		expectEnvError[envTestInt16, int16](
+			"ENV_TEST_INT16",
 			"<not-numeric>",
-			`the IMBUE_INT16 environment variable cannot be parsed: "<not-numeric>" is not a valid int16`,
+			`the ENV_TEST_INT16 environment variable ("<not-numeric>") is invalid: expected integer between -32768 and 32767`,
 		)
 	})
 
 	It("returns an error when an int32 cannot be parsed", func() {
-		expectEnvError[IMBUE_INT32, int32](
-			container,
-			"IMBUE_INT32",
+		expectEnvError[envTestInt32, int32](
+			"ENV_TEST_INT32",
 			"<not-numeric>",
-			`the IMBUE_INT32 environment variable cannot be parsed: "<not-numeric>" is not a valid int32`,
+			`the ENV_TEST_INT32 environment variable ("<not-numeric>") is invalid: expected integer between -2147483648 and 2147483647`,
 		)
 	})
 
 	It("returns an error when an int64 cannot be parsed", func() {
-		expectEnvError[IMBUE_INT64, int64](
-			container,
-			"IMBUE_INT64",
+		expectEnvError[envTestInt64, int64](
+			"ENV_TEST_INT64",
 			"<not-numeric>",
-			`the IMBUE_INT64 environment variable cannot be parsed: "<not-numeric>" is not a valid int64`,
+			`the ENV_TEST_INT64 environment variable ("<not-numeric>") is invalid: expected integer between -9223372036854775808 and 9223372036854775807`,
 		)
 	})
 
 	It("returns an error when a uint cannot be parsed", func() {
-		expectEnvError[IMBUE_UINT, uint](
-			container,
-			"IMBUE_UINT",
+		expectEnvError[envTestUint, uint](
+			"ENV_TEST_UINT",
 			"<not-numeric>",
-			`the IMBUE_UINT environment variable cannot be parsed: "<not-numeric>" is not a valid uint`,
+			`the ENV_TEST_UINT environment variable ("<not-numeric>") is invalid: expected integer between 0 and 18446744073709551615`,
 		)
 	})
 
 	It("returns an error when a uint16 cannot be parsed", func() {
-		expectEnvError[IMBUE_UINT16, uint16](
-			container,
-			"IMBUE_UINT16",
+		expectEnvError[envTestUint16, uint16](
+			"ENV_TEST_UINT16",
 			"<not-numeric>",
-			`the IMBUE_UINT16 environment variable cannot be parsed: "<not-numeric>" is not a valid uint16`,
+			`the ENV_TEST_UINT16 environment variable ("<not-numeric>") is invalid: expected integer between 0 and 65535`,
 		)
 	})
 
 	It("returns an error when a uint32 cannot be parsed", func() {
-		expectEnvError[IMBUE_UINT32, uint32](
-			container,
-			"IMBUE_UINT32",
+		expectEnvError[envTestUint32, uint32](
+			"ENV_TEST_UINT32",
 			"<not-numeric>",
-			`the IMBUE_UINT32 environment variable cannot be parsed: "<not-numeric>" is not a valid uint32`,
+			`the ENV_TEST_UINT32 environment variable ("<not-numeric>") is invalid: expected integer between 0 and 4294967295`,
 		)
 	})
 
 	It("returns an error when a uint64 cannot be parsed", func() {
-		expectEnvError[IMBUE_UINT64, uint64](
-			container,
-			"IMBUE_UINT64",
+		expectEnvError[envTestUint64, uint64](
+			"ENV_TEST_UINT64",
 			"<not-numeric>",
-			`the IMBUE_UINT64 environment variable cannot be parsed: "<not-numeric>" is not a valid uint64`,
+			`the ENV_TEST_UINT64 environment variable ("<not-numeric>") is invalid: expected integer between 0 and 18446744073709551615`,
 		)
 	})
 
 	It("returns an error when a float32 cannot be parsed", func() {
-		expectEnvError[IMBUE_FLOAT32, float32](
-			container,
-			"IMBUE_FLOAT32",
+		expectEnvError[envTestFloat32, float32](
+			"ENV_TEST_FLOAT32",
 			"<not-numeric>",
-			`the IMBUE_FLOAT32 environment variable cannot be parsed: "<not-numeric>" is not a valid float32`,
+			`the ENV_TEST_FLOAT32 environment variable ("<not-numeric>") is invalid: expected floating-point number`,
 		)
 	})
 
 	It("returns an error when a float64 cannot be parsed", func() {
-		expectEnvError[IMBUE_FLOAT64, float64](
-			container,
-			"IMBUE_FLOAT64",
+		expectEnvError[envTestFloat64, float64](
+			"ENV_TEST_FLOAT64",
 			"<not-numeric>",
-			`the IMBUE_FLOAT64 environment variable cannot be parsed: "<not-numeric>" is not a valid float64`,
+			`the ENV_TEST_FLOAT64 environment variable ("<not-numeric>") is invalid: expected floating-point number`,
 		)
 	})
 
 	It("returns an error when the environment variable is undefined", func() {
+		con := imbue.New()
+		defer con.Close()
+
 		err := imbue.Invoke1(
 			context.Background(),
-			container,
+			con,
 			func(
 				ctx context.Context,
-				v imbue.FromEnvironment[IMBUE_STRING, string],
+				v imbue.FromEnvironment[envTestString, string],
 			) error {
 				Fail("unexpected call")
 				return nil
 			},
 		)
-		Expect(err).To(MatchError("the IMBUE_STRING environment variable is not defined"))
+		Expect(err).To(MatchError("the ENV_TEST_STRING environment variable is not defined"))
 	})
 
 	It("returns an error when the environment variable is empty", func() {
-		os.Setenv("IMBUE_STRING", "")
-		defer os.Unsetenv("IMBUE_STRING")
+		os.Setenv("ENV_TEST_STRING", "")
+		defer os.Unsetenv("ENV_TEST_STRING")
+
+		con := imbue.New()
+		defer con.Close()
 
 		err := imbue.Invoke1(
 			context.Background(),
-			container,
+			con,
 			func(
 				ctx context.Context,
-				v imbue.FromEnvironment[IMBUE_STRING, string],
+				v imbue.FromEnvironment[envTestString, string],
 			) error {
 				Fail("unexpected call")
 				return nil
 			},
 		)
-		Expect(err).To(MatchError("the IMBUE_STRING environment variable is defined, but it is empty"))
+		Expect(err).To(MatchError("the ENV_TEST_STRING environment variable is defined, but it is empty"))
 	})
 })
 
@@ -182,13 +174,15 @@ func expectEnv[
 	V imbue.EnvironmentVariable[T],
 	T imbue.Parseable,
 ](
-	con *imbue.Container,
 	name string,
-	stringValue string,
-	parsedValue T,
+	raw string,
+	value T,
 ) {
-	os.Setenv(name, stringValue)
+	os.Setenv(name, raw)
 	defer os.Unsetenv(name)
+
+	con := imbue.New()
+	defer con.Close()
 
 	err := imbue.Invoke1(
 		context.Background(),
@@ -198,8 +192,8 @@ func expectEnv[
 			v imbue.FromEnvironment[V, T],
 		) error {
 			Expect(v.Name()).To(Equal(name))
-			Expect(v.Value()).To(Equal(parsedValue))
-			Expect(v.String()).To(Equal(stringValue))
+			Expect(v.Value()).To(Equal(value))
+			Expect(v.String()).To(Equal(raw))
 			return nil
 		},
 	)
@@ -209,13 +203,12 @@ func expectEnv[
 func expectEnvError[
 	V imbue.EnvironmentVariable[T],
 	T imbue.Parseable,
-](
-	con *imbue.Container,
-	name string,
-	stringValue string,
-	errorMessage string,
-) {
-	os.Setenv(name, stringValue)
+](name, raw, message string) {
+	os.Setenv(name, raw)
+	defer os.Unsetenv(name)
+
+	con := imbue.New()
+	defer con.Close()
 
 	err := imbue.Invoke1(
 		context.Background(),
@@ -228,5 +221,5 @@ func expectEnvError[
 			return nil
 		},
 	)
-	Expect(err).To(MatchError(errorMessage))
+	Expect(err).To(MatchError(message))
 }

--- a/environment_test.go
+++ b/environment_test.go
@@ -21,6 +21,9 @@ type (
 	IMBUE_UINT16 imbue.EnvironmentVariable[uint16]
 	IMBUE_UINT32 imbue.EnvironmentVariable[uint32]
 	IMBUE_UINT64 imbue.EnvironmentVariable[uint64]
+
+	IMBUE_FLOAT32 imbue.EnvironmentVariable[float32]
+	IMBUE_FLOAT64 imbue.EnvironmentVariable[float64]
 )
 
 var _ = Describe("func FromEnvironment()", func() {
@@ -46,6 +49,9 @@ var _ = Describe("func FromEnvironment()", func() {
 		expectEnv[IMBUE_UINT16](container, "IMBUE_UINT16", "123", uint16(123))
 		expectEnv[IMBUE_UINT32](container, "IMBUE_UINT32", "123", uint32(123))
 		expectEnv[IMBUE_UINT64](container, "IMBUE_UINT64", "123", uint64(123))
+
+		expectEnv[IMBUE_FLOAT32](container, "IMBUE_FLOAT32", "-123.45", float32(-123.45))
+		expectEnv[IMBUE_FLOAT64](container, "IMBUE_FLOAT64", "-123.45", float64(-123.45))
 	})
 
 	It("returns an error when an int cannot be parsed", func() {
@@ -117,6 +123,24 @@ var _ = Describe("func FromEnvironment()", func() {
 			"IMBUE_UINT64",
 			"<not-numeric>",
 			`the IMBUE_UINT64 environment variable cannot be parsed: "<not-numeric>" is not a valid uint64`,
+		)
+	})
+
+	It("returns an error when a float32 cannot be parsed", func() {
+		expectEnvError[IMBUE_FLOAT32, float32](
+			container,
+			"IMBUE_FLOAT32",
+			"<not-numeric>",
+			`the IMBUE_FLOAT32 environment variable cannot be parsed: "<not-numeric>" is not a valid float32`,
+		)
+	})
+
+	It("returns an error when a float64 cannot be parsed", func() {
+		expectEnvError[IMBUE_FLOAT64, float64](
+			container,
+			"IMBUE_FLOAT64",
+			"<not-numeric>",
+			`the IMBUE_FLOAT64 environment variable cannot be parsed: "<not-numeric>" is not a valid float64`,
 		)
 	})
 

--- a/environment_test.go
+++ b/environment_test.go
@@ -14,6 +14,8 @@ import (
 type (
 	envTestString imbue.EnvironmentVariable[string]
 
+	envTestBool imbue.EnvironmentVariable[bool]
+
 	envTestInt   imbue.EnvironmentVariable[int]
 	envTestInt16 imbue.EnvironmentVariable[int16]
 	envTestInt32 imbue.EnvironmentVariable[int32]
@@ -32,6 +34,13 @@ var _ = Describe("func FromEnvironment()", func() {
 	It("can parse environment variables", func() {
 		expectEnv[envTestString]("ENV_TEST_STRING", "<value>", "<value>")
 
+		expectEnv[envTestBool]("ENV_TEST_BOOL", "TrUe", true)
+		expectEnv[envTestBool]("ENV_TEST_BOOL", "fAlSe", false)
+		expectEnv[envTestBool]("ENV_TEST_BOOL", "YeS", true)
+		expectEnv[envTestBool]("ENV_TEST_BOOL", "nO", false)
+		expectEnv[envTestBool]("ENV_TEST_BOOL", "On", true)
+		expectEnv[envTestBool]("ENV_TEST_BOOL", "oFf", false)
+
 		expectEnv[envTestInt]("ENV_TEST_INT", "-123", int(-123))
 		expectEnv[envTestInt16]("ENV_TEST_INT16", "-123", int16(-123))
 		expectEnv[envTestInt32]("ENV_TEST_INT32", "-123", int32(-123))
@@ -44,6 +53,14 @@ var _ = Describe("func FromEnvironment()", func() {
 
 		expectEnv[envTestFloat32]("ENV_TEST_FLOAT32", "-123.45", float32(-123.45))
 		expectEnv[envTestFloat64]("ENV_TEST_FLOAT64", "-123.45", float64(-123.45))
+	})
+
+	It("returns an error when a bool cannot be parsed", func() {
+		expectEnvError[envTestBool, bool](
+			"ENV_TEST_BOOL",
+			"<not-bool>",
+			`the ENV_TEST_BOOL environment variable ("<not-bool>") is invalid: expected one of "true", "false", "yes", "no", "on" or "off"`,
+		)
 	})
 
 	It("returns an error when an int cannot be parsed", func() {

--- a/environment_test.go
+++ b/environment_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"time"
 
 	"github.com/dogmatiq/imbue"
 	. "github.com/onsi/ginkgo/v2"
@@ -12,9 +13,10 @@ import (
 )
 
 type (
-	envTestString imbue.EnvironmentVariable[string]
-	envTestBytes  imbue.EnvironmentVariable[[]byte]
-	envTestBool   imbue.EnvironmentVariable[bool]
+	envTestString   imbue.EnvironmentVariable[string]
+	envTestBytes    imbue.EnvironmentVariable[[]byte]
+	envTestBool     imbue.EnvironmentVariable[bool]
+	envTestDuration imbue.EnvironmentVariable[time.Duration]
 
 	envTestInt   imbue.EnvironmentVariable[int]
 	envTestInt16 imbue.EnvironmentVariable[int16]
@@ -33,8 +35,8 @@ type (
 var _ = Describe("func FromEnvironment()", func() {
 	It("can parse environment variables", func() {
 		expectEnv[envTestString]("ENV_TEST_STRING", "<value>", "<value>")
-
 		expectEnv[envTestBytes]("ENV_TEST_BYTES", "<value>", []byte("<value>"))
+		expectEnv[envTestDuration]("ENV_TEST_DURATION", "1.5s", 1500*time.Millisecond)
 
 		expectEnv[envTestBool]("ENV_TEST_BOOL", "TrUe", true)
 		expectEnv[envTestBool]("ENV_TEST_BOOL", "fAlSe", false)
@@ -62,6 +64,14 @@ var _ = Describe("func FromEnvironment()", func() {
 			"ENV_TEST_BOOL",
 			"<not-bool>",
 			`the ENV_TEST_BOOL environment variable ("<not-bool>") is invalid: expected one of "true", "false", "yes", "no", "on" or "off"`,
+		)
+	})
+
+	It("returns an error when a duration cannot be parsed", func() {
+		expectEnvError[envTestDuration, time.Duration](
+			"ENV_TEST_DURATION",
+			"<not-duration>",
+			`the ENV_TEST_DURATION environment variable ("<not-duration>") is invalid: expected duration (e.g. "300ms", "-1.5h" or "2h45m")`,
 		)
 	})
 

--- a/environment_test.go
+++ b/environment_test.go
@@ -13,8 +13,8 @@ import (
 
 type (
 	envTestString imbue.EnvironmentVariable[string]
-
-	envTestBool imbue.EnvironmentVariable[bool]
+	envTestBytes  imbue.EnvironmentVariable[[]byte]
+	envTestBool   imbue.EnvironmentVariable[bool]
 
 	envTestInt   imbue.EnvironmentVariable[int]
 	envTestInt16 imbue.EnvironmentVariable[int16]
@@ -33,6 +33,8 @@ type (
 var _ = Describe("func FromEnvironment()", func() {
 	It("can parse environment variables", func() {
 		expectEnv[envTestString]("ENV_TEST_STRING", "<value>", "<value>")
+
+		expectEnv[envTestBytes]("ENV_TEST_BYTES", "<value>", []byte("<value>"))
 
 		expectEnv[envTestBool]("ENV_TEST_BOOL", "TrUe", true)
 		expectEnv[envTestBool]("ENV_TEST_BOOL", "fAlSe", false)

--- a/environment_test.go
+++ b/environment_test.go
@@ -1,0 +1,164 @@
+package imbue_test
+
+import (
+	"context"
+	"os"
+
+	"github.com/dogmatiq/imbue"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type (
+	IMBUE_STRING imbue.EnvironmentVariable[string]
+
+	IMBUE_INT   imbue.EnvironmentVariable[int]
+	IMBUE_INT16 imbue.EnvironmentVariable[int16]
+
+	IMBUE_UINT   imbue.EnvironmentVariable[uint]
+	IMBUE_UINT16 imbue.EnvironmentVariable[uint16]
+)
+
+var _ = Describe("func FromEnvironment()", func() {
+	var container *imbue.Container
+
+	BeforeEach(func() {
+		container = imbue.New()
+	})
+
+	AfterEach(func() {
+		container.Close()
+	})
+
+	It("can parse environment variables", func() {
+		expectEnv[IMBUE_STRING](container, "IMBUE_STRING", "<value>", "<value>")
+
+		expectEnv[IMBUE_INT](container, "IMBUE_INT", "-123", int(-123))
+		expectEnv[IMBUE_INT16](container, "IMBUE_INT16", "-123", int16(-123))
+
+		expectEnv[IMBUE_UINT](container, "IMBUE_UINT", "123", uint(123))
+		expectEnv[IMBUE_UINT16](container, "IMBUE_UINT16", "123", uint16(123))
+	})
+
+	It("returns an error when an int cannot be parsed", func() {
+		expectEnvError[IMBUE_INT, int](
+			container,
+			"IMBUE_INT",
+			"<not-numeric>",
+			`the IMBUE_INT environment variable cannot be parsed: "<not-numeric>" is not a valid int`,
+		)
+	})
+
+	It("returns an error when an int16 cannot be parsed", func() {
+		expectEnvError[IMBUE_INT16, int16](
+			container,
+			"IMBUE_INT16",
+			"<not-numeric>",
+			`the IMBUE_INT16 environment variable cannot be parsed: "<not-numeric>" is not a valid int16`,
+		)
+	})
+
+	It("returns an error when a uint cannot be parsed", func() {
+		expectEnvError[IMBUE_UINT, uint](
+			container,
+			"IMBUE_UINT",
+			"<not-numeric>",
+			`the IMBUE_UINT environment variable cannot be parsed: "<not-numeric>" is not a valid uint`,
+		)
+	})
+
+	It("returns an error when a uint16 cannot be parsed", func() {
+		expectEnvError[IMBUE_UINT16, uint16](
+			container,
+			"IMBUE_UINT16",
+			"<not-numeric>",
+			`the IMBUE_UINT16 environment variable cannot be parsed: "<not-numeric>" is not a valid uint16`,
+		)
+	})
+
+	It("returns an error when the environment variable is undefined", func() {
+		err := imbue.Invoke1(
+			context.Background(),
+			container,
+			func(
+				ctx context.Context,
+				v imbue.FromEnvironment[IMBUE_STRING, string],
+			) error {
+				Fail("unexpected call")
+				return nil
+			},
+		)
+		Expect(err).To(MatchError("the IMBUE_STRING environment variable is not defined"))
+	})
+
+	It("returns an error when the environment variable is empty", func() {
+		os.Setenv("IMBUE_STRING", "")
+		defer os.Unsetenv("IMBUE_STRING")
+
+		err := imbue.Invoke1(
+			context.Background(),
+			container,
+			func(
+				ctx context.Context,
+				v imbue.FromEnvironment[IMBUE_STRING, string],
+			) error {
+				Fail("unexpected call")
+				return nil
+			},
+		)
+		Expect(err).To(MatchError("the IMBUE_STRING environment variable is defined, but it is empty"))
+	})
+})
+
+func expectEnv[
+	V imbue.EnvironmentVariable[T],
+	T imbue.Parseable,
+](
+	con *imbue.Container,
+	name string,
+	stringValue string,
+	parsedValue T,
+) {
+	os.Setenv(name, stringValue)
+	defer os.Unsetenv(name)
+
+	err := imbue.Invoke1(
+		context.Background(),
+		con,
+		func(
+			ctx context.Context,
+			v imbue.FromEnvironment[V, T],
+		) error {
+			Expect(v.Name()).To(Equal(name))
+			Expect(v.Value()).To(Equal(parsedValue))
+			Expect(v.String()).To(Equal(stringValue))
+			return nil
+		},
+	)
+	Expect(err).ShouldNot(HaveOccurred())
+}
+
+func expectEnvError[
+	V imbue.EnvironmentVariable[T],
+	T imbue.Parseable,
+](
+	con *imbue.Container,
+	name string,
+	stringValue string,
+	errorMessage string,
+) {
+	os.Setenv(name, stringValue)
+
+	err := imbue.Invoke1(
+		context.Background(),
+		con,
+		func(
+			ctx context.Context,
+			v imbue.FromEnvironment[V, T],
+		) error {
+			Fail("unexpected call")
+			return nil
+		},
+	)
+	Expect(err).To(MatchError(errorMessage))
+}

--- a/environment_test.go
+++ b/environment_test.go
@@ -14,9 +14,13 @@ type (
 
 	IMBUE_INT   imbue.EnvironmentVariable[int]
 	IMBUE_INT16 imbue.EnvironmentVariable[int16]
+	IMBUE_INT32 imbue.EnvironmentVariable[int32]
+	IMBUE_INT64 imbue.EnvironmentVariable[int64]
 
 	IMBUE_UINT   imbue.EnvironmentVariable[uint]
 	IMBUE_UINT16 imbue.EnvironmentVariable[uint16]
+	IMBUE_UINT32 imbue.EnvironmentVariable[uint32]
+	IMBUE_UINT64 imbue.EnvironmentVariable[uint64]
 )
 
 var _ = Describe("func FromEnvironment()", func() {
@@ -35,9 +39,13 @@ var _ = Describe("func FromEnvironment()", func() {
 
 		expectEnv[IMBUE_INT](container, "IMBUE_INT", "-123", int(-123))
 		expectEnv[IMBUE_INT16](container, "IMBUE_INT16", "-123", int16(-123))
+		expectEnv[IMBUE_INT32](container, "IMBUE_INT32", "-123", int32(-123))
+		expectEnv[IMBUE_INT64](container, "IMBUE_INT64", "-123", int64(-123))
 
 		expectEnv[IMBUE_UINT](container, "IMBUE_UINT", "123", uint(123))
 		expectEnv[IMBUE_UINT16](container, "IMBUE_UINT16", "123", uint16(123))
+		expectEnv[IMBUE_UINT32](container, "IMBUE_UINT32", "123", uint32(123))
+		expectEnv[IMBUE_UINT64](container, "IMBUE_UINT64", "123", uint64(123))
 	})
 
 	It("returns an error when an int cannot be parsed", func() {
@@ -58,6 +66,24 @@ var _ = Describe("func FromEnvironment()", func() {
 		)
 	})
 
+	It("returns an error when an int32 cannot be parsed", func() {
+		expectEnvError[IMBUE_INT32, int32](
+			container,
+			"IMBUE_INT32",
+			"<not-numeric>",
+			`the IMBUE_INT32 environment variable cannot be parsed: "<not-numeric>" is not a valid int32`,
+		)
+	})
+
+	It("returns an error when an int64 cannot be parsed", func() {
+		expectEnvError[IMBUE_INT64, int64](
+			container,
+			"IMBUE_INT64",
+			"<not-numeric>",
+			`the IMBUE_INT64 environment variable cannot be parsed: "<not-numeric>" is not a valid int64`,
+		)
+	})
+
 	It("returns an error when a uint cannot be parsed", func() {
 		expectEnvError[IMBUE_UINT, uint](
 			container,
@@ -73,6 +99,24 @@ var _ = Describe("func FromEnvironment()", func() {
 			"IMBUE_UINT16",
 			"<not-numeric>",
 			`the IMBUE_UINT16 environment variable cannot be parsed: "<not-numeric>" is not a valid uint16`,
+		)
+	})
+
+	It("returns an error when a uint32 cannot be parsed", func() {
+		expectEnvError[IMBUE_UINT32, uint32](
+			container,
+			"IMBUE_UINT32",
+			"<not-numeric>",
+			`the IMBUE_UINT32 environment variable cannot be parsed: "<not-numeric>" is not a valid uint32`,
+		)
+	})
+
+	It("returns an error when a uint64 cannot be parsed", func() {
+		expectEnvError[IMBUE_UINT64, uint64](
+			container,
+			"IMBUE_UINT64",
+			"<not-numeric>",
+			`the IMBUE_UINT64 environment variable cannot be parsed: "<not-numeric>" is not a valid uint64`,
 		)
 	})
 

--- a/environmentexample_test.go
+++ b/environmentexample_test.go
@@ -1,0 +1,49 @@
+package imbue_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/dogmatiq/imbue"
+)
+
+type (
+	// API_HOST_NAME declares the API_HOST_NAME environment variable as a string.
+	API_HOST_NAME imbue.EnvironmentVariable[string]
+
+	// API_PORT declares the API_PORT environment variable as a uint16.
+	API_PORT imbue.EnvironmentVariable[uint16]
+)
+
+func Example_environmentVariables() {
+	// Set some environment variables to use in our example.
+	os.Setenv("API_HOST_NAME", "server.example.org")
+	os.Setenv("API_PORT", "8080")
+
+	con := imbue.New()
+	defer con.Close()
+
+	// Invoke a function that depends on both the API_HOST_NAME and API_PORT
+	// environment variables.
+	err := imbue.Invoke2(
+		context.Background(),
+		con,
+		func(
+			ctx context.Context,
+			h imbue.FromEnvironment[API_HOST_NAME, string],
+			p imbue.FromEnvironment[API_PORT, uint16],
+		) error {
+			fmt.Println(h.Name(), "=", h.Value())
+			fmt.Println(p.Name(), "=", p.Value())
+			return nil
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// API_HOST_NAME = server.example.org
+	// API_PORT = 8080
+}

--- a/environmentexample_test.go
+++ b/environmentexample_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 type (
-	// API_HOST_NAME declares the API_HOST_NAME environment variable as a string.
-	API_HOST_NAME imbue.EnvironmentVariable[string]
+	// APIHostName declares the API_HOST_NAME environment variable as a string.
+	APIHostName imbue.EnvironmentVariable[string]
 
-	// API_PORT declares the API_PORT environment variable as a uint16.
-	API_PORT imbue.EnvironmentVariable[uint16]
+	// APIPort declares the API_PORT environment variable as a uint16.
+	APIPort imbue.EnvironmentVariable[uint16]
 )
 
 func Example_environmentVariables() {
@@ -31,8 +31,8 @@ func Example_environmentVariables() {
 		con,
 		func(
 			ctx context.Context,
-			h imbue.FromEnvironment[API_HOST_NAME, string],
-			p imbue.FromEnvironment[API_PORT, uint16],
+			h imbue.FromEnvironment[APIHostName, string],
+			p imbue.FromEnvironment[APIPort, uint16],
 		) error {
 			fmt.Println(h.Name(), "=", h.Value())
 			fmt.Println(p.Name(), "=", p.Value())

--- a/internal/identifier/convert.go
+++ b/internal/identifier/convert.go
@@ -1,0 +1,50 @@
+package identifier
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// ToScreamingSnakeCase converts a Go identifier to SCREAMING_SNAKE_CASE.
+func ToScreamingSnakeCase(camel string) string {
+	var (
+		wordIsUpper bool
+		wordLen     int
+		result      strings.Builder
+	)
+
+	for pos, ch := range camel {
+		if pos == 0 {
+			wordIsUpper = unicode.IsUpper(ch)
+		} else if wordIsUpper {
+			if unicode.IsLower(ch) {
+				wordIsUpper = false
+
+				if wordLen > 1 {
+					wordLen = 0
+
+					res := result.String()
+					result.Reset()
+
+					last, size := utf8.DecodeLastRuneInString(res)
+					result.WriteString(res[:len(res)-size])
+
+					result.WriteRune('_')
+					result.WriteRune(last)
+				}
+			}
+		} else {
+			if unicode.IsUpper(ch) {
+				wordIsUpper = true
+				wordLen = 0
+				result.WriteRune('_')
+			}
+		}
+
+		result.WriteRune(unicode.ToUpper(ch))
+		wordLen++
+	}
+
+	return result.String()
+}

--- a/internal/identifier/convert_test.go
+++ b/internal/identifier/convert_test.go
@@ -1,0 +1,31 @@
+package identifier_test
+
+import (
+	. "github.com/dogmatiq/imbue/internal/identifier"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func ToScreamingSnakeCase()", func() {
+	DescribeTable(
+		"it converts a string to SCREAMING_SNAKE_CASE",
+		func(camel, expect string) {
+			Expect(ToScreamingSnakeCase(camel)).To(Equal(expect))
+		},
+		Entry("2-word identity", "FOO_BAR", "FOO_BAR"),
+		Entry("2-word camel case", "fooBar", "FOO_BAR"),
+		Entry("2-word pascal case", "FooBar", "FOO_BAR"),
+		Entry("2-word initialism at start", "FOOBar", "FOO_BAR"),
+		Entry("2-word initialism at end", "FooBAR", "FOO_BAR"),
+
+		Entry("3-word identity", "FOO_BAR_SPAM", "FOO_BAR_SPAM"),
+		Entry("3-word camel case", "fooBarSpam", "FOO_BAR_SPAM"),
+		Entry("3-word pascal case", "FooBarSpam", "FOO_BAR_SPAM"),
+		Entry("3-word initialism at start", "FOOBarSpam", "FOO_BAR_SPAM"),
+		Entry("3-word initialism at middle", "FooBARSpam", "FOO_BAR_SPAM"),
+		Entry("3-word initialism at end", "FooBarSPAM", "FOO_BAR_SPAM"),
+
+		Entry("numbers", "FooBar123Spam", "FOO_BAR123_SPAM"),
+		Entry("numbers with initialism", "FooBAR123Spam", "FOO_BAR123_SPAM"),
+	)
+})

--- a/internal/identifier/convert_test.go
+++ b/internal/identifier/convert_test.go
@@ -12,6 +12,10 @@ var _ = Describe("func ToScreamingSnakeCase()", func() {
 		func(camel, expect string) {
 			Expect(ToScreamingSnakeCase(camel)).To(Equal(expect))
 		},
+		Entry("1-word identity", "FOO", "FOO"),
+		Entry("1-word camel case", "foo", "FOO"),
+		Entry("1-word pascal case", "Foo", "FOO"),
+
 		Entry("2-word identity", "FOO_BAR", "FOO_BAR"),
 		Entry("2-word camel case", "fooBar", "FOO_BAR"),
 		Entry("2-word pascal case", "FooBar", "FOO_BAR"),

--- a/internal/identifier/ginkgo_test.go
+++ b/internal/identifier/ginkgo_test.go
@@ -1,0 +1,15 @@
+package identifier_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	type tag struct{}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, reflect.TypeOf(tag{}).PkgPath())
+}

--- a/withgrouped.go
+++ b/withgrouped.go
@@ -5,7 +5,7 @@ package imbue
 // Groups are used to group multiple dependencies of different types that are
 // related in some way.
 //
-// Groups are declared by declaring a named type that uses imbue.Group as its
+// Groups are defined by declaring a named type that uses imbue.Group as its
 // underlying type.
 type Group interface {
 	group()

--- a/withnamed.go
+++ b/withnamed.go
@@ -4,7 +4,7 @@ package imbue
 //
 // Names are used to distinguish between multiple dependencies of the same type.
 //
-// Names are declared by declaring a type that uses imbue.Name[T] as its
+// Names are defined by declaring a type that uses imbue.Name[T] as its
 // underlying type, where T is the type of the dependency being named.
 type Name[T any] interface {
 	nameOf(T)


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds support for reading environment variables as dependencies and parsing their value into various types.
It works similarly to named dependencies (see [the example](https://github.com/dogmatiq/imbue/blob/env/environmentexample_test.go) in this PR).

#### Why make this change?

It is very common to read environment variables during DI.

#### Is there anything you are unsure about?

The current implementation uses the name of the user-defined type as the name of the environment variable. This leads to the use of `SCREAMING_SNAKE_CASE` which is common for environment variables, but unusual for Go type names.

This may cause problems with some linters, and/or force the user to export the type when they may not wish to.

Another approach might be to allow `[cC]amelCaseNaming` for the type and convert that to `CAMEL_CASE_NAMING` for the call to `os.Getenv()`.

#### What issues does this relate to?

None
