### PR TITLE
Call deferred functions when construction fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - `DecorateX()` now panics when called for a type that has already been constructed
 - `Container.Close()` now gives file/line information about deferred functions that return an error
+- Functions deferred by `Context.Defer()` are now called immediately if the constructor (or a decorator) fails
 
 ## [0.5.0] - 2022-06-29
 

--- a/construct.go
+++ b/construct.go
@@ -21,13 +21,8 @@ type constructor[T any] struct {
 }
 
 // Call invokes the constructor and returns the constructed value.
-func (c constructor[T]) Call(ctx *Context) (T, error) {
-	ctx = &Context{
-		Context:  ctx,
-		deferrer: ctx.deferrer,
-		scope:    c,
-	}
-
+func (c constructor[T]) Call(ctx *Context, defers *deferSet) (T, error) {
+	ctx = childContext(ctx, c, defers)
 	v, err := c.impl(ctx)
 	if err != nil {
 		if c.rawErr {

--- a/context.go
+++ b/context.go
@@ -9,13 +9,14 @@ import (
 type Context struct {
 	context.Context
 
-	deferrer *deferrer
-	scope    userFunction
+	con    *Container
+	scope  userFunction
+	defers *deferSet
 }
 
 // Defer registers a function to be invoked when the container is closed.
 func (c *Context) Defer(fn func() error) {
-	c.deferrer.Add(
+	c.defers.Add(
 		deferred{
 			fn,
 			findLocation(),
@@ -24,10 +25,28 @@ func (c *Context) Defer(fn func() error) {
 	)
 }
 
-// rootContext returns a new root context.
-func rootContext(ctx context.Context, con *Container) *Context {
+// invokeContext returns a new Context for a function invoked by InvokeX().
+func invokeContext(
+	parent context.Context,
+	con *Container,
+) *Context {
 	return &Context{
-		Context:  ctx,
-		deferrer: &con.deferrer,
+		Context: parent,
+		con:     con,
+	}
+}
+
+// childContext returns a new child Context for use within a constructor or
+// decorator.
+func childContext(
+	parent *Context,
+	scope userFunction,
+	defers *deferSet,
+) *Context {
+	return &Context{
+		Context: parent,
+		con:     parent.con,
+		scope:   scope,
+		defers:  defers,
 	}
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,588 @@
+package imbue_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/dogmatiq/imbue"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Context", func() {
+	var container *imbue.Container
+
+	BeforeEach(func() {
+		container = imbue.New()
+	})
+
+	AfterEach(func() {
+		container.Close()
+	})
+
+	Describe("func Defer()", func() {
+		When("construction and decoration succeeds", func() {
+			It("defers calling functions deferred by constructors until the container is closed", func() {
+				called := false
+				imbue.With0(
+					container,
+					func(
+						ctx *imbue.Context,
+					) (Concrete1, error) {
+						ctx.Defer(func() error {
+							called = true
+							return nil
+						})
+						return "<concrete>", nil
+					},
+				)
+
+				err := imbue.Invoke1(
+					context.Background(),
+					container,
+					func(
+						context.Context,
+						Concrete1,
+					) error {
+						return nil
+					},
+				)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(called).To(BeFalse())
+
+				err = container.Close()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(called).To(BeTrue())
+			})
+
+			It("defers calling functions deferred by decorators until the container is closed", func() {
+				imbue.With0(
+					container,
+					func(
+						ctx *imbue.Context,
+					) (Concrete1, error) {
+						return "<concrete>", nil
+					},
+				)
+
+				called := false
+				imbue.Decorate0(
+					container,
+					func(
+						ctx *imbue.Context,
+						dep Concrete1,
+					) (Concrete1, error) {
+						ctx.Defer(func() error {
+							called = true
+							return nil
+						})
+						return dep, nil
+					},
+				)
+
+				err := imbue.Invoke1(
+					context.Background(),
+					container,
+					func(
+						context.Context,
+						Concrete1,
+					) error {
+						return nil
+					},
+				)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(called).To(BeFalse())
+
+				err = container.Close()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(called).To(BeTrue())
+			})
+
+			It("calls deferred functions in reverse order", func() {
+				var order []string
+
+				imbue.With0(
+					container,
+					func(
+						ctx *imbue.Context,
+					) (Concrete1, error) {
+						ctx.Defer(func() error {
+							order = append(order, "<concrete-1-constructor>")
+							return nil
+						})
+						return "<concrete-1>", nil
+					},
+				)
+
+				imbue.Decorate0(
+					container,
+					func(
+						ctx *imbue.Context,
+						dep Concrete1,
+					) (Concrete1, error) {
+						ctx.Defer(func() error {
+							order = append(order, "<concrete-1-decorator>")
+							return nil
+						})
+						return dep, nil
+					},
+				)
+
+				imbue.With1(
+					container,
+					func(
+						ctx *imbue.Context,
+						_ Concrete1,
+					) (Concrete2, error) {
+						ctx.Defer(func() error {
+							order = append(order, "<concrete-2-constructor>")
+							return nil
+						})
+						return "<concrete-2>", nil
+					},
+				)
+
+				err := imbue.Invoke1(
+					context.Background(),
+					container,
+					func(
+						context.Context,
+						Concrete2,
+					) error {
+						return nil
+					},
+				)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				err = container.Close()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(order).To(Equal([]string{
+					"<concrete-2-constructor>",
+					"<concrete-1-decorator>",
+					"<concrete-1-constructor>",
+				}))
+			})
+
+			It("produces an error when one or more deferred functions fails", func() {
+				imbue.With0(
+					container,
+					func(
+						ctx *imbue.Context,
+					) (Concrete1, error) {
+						ctx.Defer(func() error {
+							return errors.New("<concrete-1-constructor>")
+						})
+						return "<concrete-1>", nil
+					},
+				)
+
+				imbue.Decorate0(
+					container,
+					func(
+						ctx *imbue.Context,
+						dep Concrete1,
+					) (Concrete1, error) {
+						ctx.Defer(func() error {
+							return errors.New("<concrete-1-decorator>")
+						})
+						return dep, nil
+					},
+				)
+
+				imbue.With1(
+					container,
+					func(
+						ctx *imbue.Context,
+						_ Concrete1,
+					) (Concrete2, error) {
+						ctx.Defer(func() error {
+							return errors.New("<concrete-2-constructor>")
+						})
+						return "<concrete-2>", nil
+					},
+				)
+
+				err := imbue.Invoke1(
+					context.Background(),
+					container,
+					func(
+						context.Context,
+						Concrete2,
+					) error {
+						return nil
+					},
+				)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				err = container.Close()
+				Expect(err).To(
+					MatchError(
+						MatchRegexp(
+							`3 error\(s\) occurred while closing the container:`+
+								`\n\t1\) function deferred at context_test\.go:\d+ by imbue_test\.Concrete2 constructor \(context_test\.go:\d+\) failed: <concrete-2-constructor>`+
+								`\n\t2\) function deferred at context_test\.go:\d+ by imbue_test\.Concrete1 decorator \(context_test\.go:\d+\) failed: <concrete-1-decorator>`+
+								`\n\t3\) function deferred at context_test\.go:\d+ by imbue_test\.Concrete1 constructor \(context_test\.go:\d+\) failed: <concrete-1-constructor>`,
+						),
+					),
+					err.Error(),
+				)
+			})
+		})
+
+		It("guarantees all deferred functions are called when there is a panic", func() {
+			count := 0
+
+			imbue.With0(
+				container,
+				func(
+					ctx *imbue.Context,
+				) (Concrete1, error) {
+					ctx.Defer(func() error {
+						count++
+						return nil
+					})
+					return "<concrete-1>", nil
+				},
+			)
+
+			imbue.Decorate0(
+				container,
+				func(
+					ctx *imbue.Context,
+					dep Concrete1,
+				) (Concrete1, error) {
+					ctx.Defer(func() error {
+						count++
+						panic("<panic>")
+					})
+					return dep, nil
+				},
+			)
+
+			imbue.With1(
+				container,
+				func(
+					ctx *imbue.Context,
+					_ Concrete1,
+				) (Concrete2, error) {
+					ctx.Defer(func() error {
+						count++
+						return nil
+					})
+					return "<concrete-2>", nil
+				},
+			)
+
+			err := imbue.Invoke1(
+				context.Background(),
+				container,
+				func(
+					context.Context,
+					Concrete2,
+				) error {
+					return nil
+				},
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(func() {
+				container.Close()
+			}).To(PanicWith("<panic>"))
+
+			Expect(count).To(BeNumerically("==", 3))
+		})
+
+		It("does not call deferred functions again when the container is closed a second time", func() {
+			closingAgain := false
+			imbue.With0(
+				container,
+				func(
+					ctx *imbue.Context,
+				) (Concrete1, error) {
+					ctx.Defer(func() error {
+						if closingAgain {
+							Fail("unexpected call")
+						}
+						return nil
+					})
+					return "<concrete>", nil
+				},
+			)
+
+			imbue.Decorate0(
+				container,
+				func(
+					ctx *imbue.Context,
+					dep Concrete1,
+				) (Concrete1, error) {
+					ctx.Defer(func() error {
+						if closingAgain {
+							Fail("unexpected call")
+						}
+						return nil
+					})
+					return "", nil
+				},
+			)
+
+			err := imbue.Invoke1(
+				context.Background(),
+				container,
+				func(
+					context.Context,
+					Concrete1,
+				) error {
+					return nil
+				},
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			err = container.Close()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			closingAgain = true
+			err = container.Close()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	When("construction and/or decoration fails", func() {
+		It("calls functions deferred by constructors immediately", func() {
+			called := false
+			imbue.With0(
+				container,
+				func(
+					ctx *imbue.Context,
+				) (Concrete1, error) {
+					ctx.Defer(func() error {
+						called = true
+						return nil
+					})
+					return "", errors.New("<error>")
+				},
+			)
+
+			err := imbue.Invoke1(
+				context.Background(),
+				container,
+				func(
+					context.Context,
+					Concrete1,
+				) error {
+					panic("unexpected call")
+				},
+			)
+			Expect(err).To(
+				MatchError(
+					MatchRegexp(
+						`imbue_test\.Concrete1 constructor \(context_test\.go:\d+\) failed: <error>`,
+					),
+				),
+			)
+			Expect(called).To(BeTrue())
+		})
+
+		It("calls functions deferred by decorators immediately", func() {
+			imbue.With0(
+				container,
+				func(
+					ctx *imbue.Context,
+				) (Concrete1, error) {
+					return "<concrete>", nil
+				},
+			)
+
+			called := false
+			imbue.Decorate0(
+				container,
+				func(
+					ctx *imbue.Context,
+					dep Concrete1,
+				) (Concrete1, error) {
+					ctx.Defer(func() error {
+						called = true
+						return nil
+					})
+					return "", errors.New("<error>")
+				},
+			)
+
+			err := imbue.Invoke1(
+				context.Background(),
+				container,
+				func(
+					context.Context,
+					Concrete1,
+				) error {
+					panic("unexpected call")
+				},
+			)
+			Expect(err).To(
+				MatchError(
+					MatchRegexp(
+						`imbue_test\.Concrete1 decorator \(context_test\.go:\d+\) failed: <error>`,
+					),
+				),
+			)
+			Expect(called).To(BeTrue())
+		})
+
+		It("calls deferred functions in reverse order", func() {
+			var order []string
+
+			imbue.With0(
+				container,
+				func(
+					ctx *imbue.Context,
+				) (Concrete1, error) {
+					ctx.Defer(func() error {
+						order = append(order, "<concrete-1-constructor>")
+						return nil
+					})
+					return "<concrete-1>", nil
+				},
+			)
+
+			imbue.Decorate0(
+				container,
+				func(
+					ctx *imbue.Context,
+					dep Concrete1,
+				) (Concrete1, error) {
+					ctx.Defer(func() error {
+						order = append(order, "<concrete-1-decorator-1>")
+						return nil
+					})
+					return "", nil
+				},
+			)
+
+			imbue.Decorate0(
+				container,
+				func(
+					ctx *imbue.Context,
+					dep Concrete1,
+				) (Concrete1, error) {
+					ctx.Defer(func() error {
+						order = append(order, "<concrete-1-decorator-2>")
+						return nil
+					})
+					return "", errors.New("<error>")
+				},
+			)
+
+			err := imbue.Invoke1(
+				context.Background(),
+				container,
+				func(
+					context.Context,
+					Concrete1,
+				) error {
+					panic("unexpected call")
+				},
+			)
+			Expect(err).Should(HaveOccurred())
+			Expect(order).To(Equal([]string{
+				"<concrete-1-decorator-2>",
+				"<concrete-1-decorator-1>",
+				"<concrete-1-constructor>",
+			}))
+		})
+
+		It("guarantees all deferred functions are called when there is a panic", func() {
+			count := 0
+
+			imbue.With0(
+				container,
+				func(
+					ctx *imbue.Context,
+				) (Concrete1, error) {
+					ctx.Defer(func() error {
+						count++
+						return nil
+					})
+					return "<concrete-1>", nil
+				},
+			)
+
+			imbue.Decorate0(
+				container,
+				func(
+					ctx *imbue.Context,
+					dep Concrete1,
+				) (Concrete1, error) {
+					ctx.Defer(func() error {
+						count++
+						panic("<panic>")
+					})
+					return dep, errors.New("<error>")
+				},
+			)
+
+			Expect(func() {
+				imbue.Invoke1(
+					context.Background(),
+					container,
+					func(
+						context.Context,
+						Concrete1,
+					) error {
+						panic("unexpected call")
+					},
+				)
+			}).To(PanicWith("<panic>"))
+
+			Expect(count).To(BeNumerically("==", 2))
+		})
+
+		It("does not call deferred functions again when the container is closed", func() {
+			closing := false
+			imbue.With0(
+				container,
+				func(
+					ctx *imbue.Context,
+				) (Concrete1, error) {
+					ctx.Defer(func() error {
+						if closing {
+							Fail("unexpected call")
+						}
+						return nil
+					})
+					return "<concrete>", nil
+				},
+			)
+
+			imbue.Decorate0(
+				container,
+				func(
+					ctx *imbue.Context,
+					dep Concrete1,
+				) (Concrete1, error) {
+					ctx.Defer(func() error {
+						if closing {
+							Fail("unexpected call")
+						}
+						return nil
+					})
+					return "", errors.New("<error>")
+				},
+			)
+
+			err := imbue.Invoke1(
+				context.Background(),
+				container,
+				func(
+					context.Context,
+					Concrete1,
+				) error {
+					return nil
+				},
+			)
+			Expect(err).Should(HaveOccurred())
+
+			closing = true
+			err = container.Close()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+})

--- a/decorate.go
+++ b/decorate.go
@@ -22,13 +22,8 @@ type decorator[T any] struct {
 }
 
 // Call returns the decorated version of v.
-func (d decorator[T]) Call(ctx *Context, v T) (T, error) {
-	ctx = &Context{
-		Context:  ctx,
-		deferrer: ctx.deferrer,
-		scope:    d,
-	}
-
+func (d decorator[T]) Call(ctx *Context, v T, defers *deferSet) (T, error) {
+	ctx = childContext(ctx, d, defers)
 	v, err := d.impl(ctx, v)
 	if err != nil {
 		return v, fmt.Errorf(

--- a/defer.go
+++ b/defer.go
@@ -2,14 +2,44 @@ package imbue
 
 import (
 	"fmt"
-	"sync"
 )
 
-// deferrer is a registry of deferred functions that are to be called when a
-// container is closed.
-type deferrer struct {
-	m      sync.Mutex
+// deferSet is a set of deferred functions.
+type deferSet struct {
 	defers []deferred
+}
+
+// Add adds a deferred function to the set.
+func (s *deferSet) Add(d deferred) {
+	s.defers = append(s.defers, d)
+}
+
+// Call invokes the deferred functions in reverse order.
+func (s *deferSet) Call() (errors []error) {
+	defers := s.defers
+	s.defers = nil
+
+	for _, e := range defers {
+		e := e // capture loop variable
+
+		// Call the deferred functions using an actual defer statement, thus
+		// guaranteeing that the functions are invoked in reverse order _and_
+		// that they are always invoked, even if one of them panics.
+		defer func() {
+			if err := e.Call(); err != nil {
+				errors = append(errors, err)
+			}
+		}()
+	}
+
+	return errors
+}
+
+// TransferOwnership transfers ownership of this set's deferred function to
+// target.
+func (s *deferSet) TransferOwnership(target *deferSet) {
+	target.defers = append(target.defers, s.defers...)
+	s.defers = nil
 }
 
 // deferred is a wrapper around a function that is deferred during construction
@@ -56,61 +86,4 @@ func (d deferred) String() string {
 		d.loc,
 		d.scope,
 	)
-}
-
-// Add registers a function to be called when the deferrer is closed.
-func (d *deferrer) Add(df deferred) {
-	d.m.Lock()
-	defer d.m.Unlock()
-
-	d.defers = append(d.defers, df)
-}
-
-// Close invokes the registered functions in reverse order.
-func (d *deferrer) Close() error {
-	d.m.Lock()
-	defer d.m.Unlock()
-
-	if errors := d.call(); len(errors) != 0 {
-		return deferError(errors)
-	}
-
-	return nil
-}
-
-func (d *deferrer) call() (errors []error) {
-	defers := d.defers
-	d.defers = nil
-
-	for _, e := range defers {
-		e := e // capture loop variable
-
-		// Call the deferred functions using an actual defer statement, thus
-		// guaranteeing that the functions are invoked in reverse order _and_
-		// that they are always invoked, even if one of them panics.
-		defer func() {
-			if err := e.Call(); err != nil {
-				errors = append(errors, err)
-			}
-		}()
-	}
-
-	return errors
-}
-
-// deferError is returned when there are one or more errors returned by deferred
-// functions.
-type deferError []error
-
-func (e deferError) Error() string {
-	message := fmt.Sprintf(
-		"%d error(s) occurred in deferred functions:",
-		len(e),
-	)
-
-	for i, err := range e {
-		message += fmt.Sprintf("\n\t%d) %s", i+1, err)
-	}
-
-	return message
 }

--- a/internal/generate/generator/invoke.go
+++ b/internal/generate/generator/invoke.go
@@ -63,7 +63,7 @@ func generateInvokeFuncBody(depCount int, code *jen.Group) {
 	code.
 		Id("rctx").
 		Op(":=").
-		Qual(pkgPath, "rootContext").
+		Qual(pkgPath, "invokeContext").
 		Call(
 			contextVar(),
 			containerVar(),

--- a/invoke.gen.go
+++ b/invoke.gen.go
@@ -11,7 +11,7 @@ func Invoke1[D any](
 	fn func(context.Context, D) error,
 	options ...InvokeOption,
 ) error {
-	rctx := rootContext(ctx, con)
+	rctx := invokeContext(ctx, con)
 
 	v1, err := get[D](con).Resolve(rctx)
 	if err != nil {
@@ -28,7 +28,7 @@ func Invoke2[D1, D2 any](
 	fn func(context.Context, D1, D2) error,
 	options ...InvokeOption,
 ) error {
-	rctx := rootContext(ctx, con)
+	rctx := invokeContext(ctx, con)
 
 	v1, err := get[D1](con).Resolve(rctx)
 	if err != nil {
@@ -50,7 +50,7 @@ func Invoke3[D1, D2, D3 any](
 	fn func(context.Context, D1, D2, D3) error,
 	options ...InvokeOption,
 ) error {
-	rctx := rootContext(ctx, con)
+	rctx := invokeContext(ctx, con)
 
 	v1, err := get[D1](con).Resolve(rctx)
 	if err != nil {
@@ -77,7 +77,7 @@ func Invoke4[D1, D2, D3, D4 any](
 	fn func(context.Context, D1, D2, D3, D4) error,
 	options ...InvokeOption,
 ) error {
-	rctx := rootContext(ctx, con)
+	rctx := invokeContext(ctx, con)
 
 	v1, err := get[D1](con).Resolve(rctx)
 	if err != nil {
@@ -109,7 +109,7 @@ func Invoke5[D1, D2, D3, D4, D5 any](
 	fn func(context.Context, D1, D2, D3, D4, D5) error,
 	options ...InvokeOption,
 ) error {
-	rctx := rootContext(ctx, con)
+	rctx := invokeContext(ctx, con)
 
 	v1, err := get[D1](con).Resolve(rctx)
 	if err != nil {
@@ -146,7 +146,7 @@ func Invoke6[D1, D2, D3, D4, D5, D6 any](
 	fn func(context.Context, D1, D2, D3, D4, D5, D6) error,
 	options ...InvokeOption,
 ) error {
-	rctx := rootContext(ctx, con)
+	rctx := invokeContext(ctx, con)
 
 	v1, err := get[D1](con).Resolve(rctx)
 	if err != nil {
@@ -188,7 +188,7 @@ func Invoke7[D1, D2, D3, D4, D5, D6, D7 any](
 	fn func(context.Context, D1, D2, D3, D4, D5, D6, D7) error,
 	options ...InvokeOption,
 ) error {
-	rctx := rootContext(ctx, con)
+	rctx := invokeContext(ctx, con)
 
 	v1, err := get[D1](con).Resolve(rctx)
 	if err != nil {
@@ -235,7 +235,7 @@ func Invoke8[D1, D2, D3, D4, D5, D6, D7, D8 any](
 	fn func(context.Context, D1, D2, D3, D4, D5, D6, D7, D8) error,
 	options ...InvokeOption,
 ) error {
-	rctx := rootContext(ctx, con)
+	rctx := invokeContext(ctx, con)
 
 	v1, err := get[D1](con).Resolve(rctx)
 	if err != nil {


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR changes the behavior of `Context.Defer()` such that the deferred functions are invoked immediately after a constructor or decorator function fails (as opposed to when the container is closed).

#### Why make this change?

When a constructor or decorator function returns an error the value is **not** considered to be constructed. Future attempts to resolve the value will result in the constructor and decorators being called again. This change ensures that any deferred functions from previous failed attempts are called before that happens.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

Fixes #17 
